### PR TITLE
Put completed items before the list of incompleted items

### DIFF
--- a/frontend/webapp/src/app/components/completed/completed.style.scss
+++ b/frontend/webapp/src/app/components/completed/completed.style.scss
@@ -1,5 +1,6 @@
 :host {
   display: block;
+  padding: 0 0 1em 0;
 }
 
 h3 {

--- a/frontend/webapp/src/app/components/completed/completed.template.html
+++ b/frontend/webapp/src/app/components/completed/completed.template.html
@@ -1,7 +1,4 @@
 <ul *ngIf="completedItems">
-  <h3>Completed Items
-    <i class="fa fa-trash" (click)="removeAll()"></i>
-  </h3>
   <li *ngFor="let completedItem of completedItems; let i = index">
     <button class="unchecked" (click)="incompleteItem(i)">
       <i class="fa fa-check-square-o"></i>

--- a/frontend/webapp/src/app/components/home/home.component.ts
+++ b/frontend/webapp/src/app/components/home/home.component.ts
@@ -16,10 +16,7 @@ export class HomeComponent implements OnInit {
    * Items of the list
    */
   public items: ListItem[] = [ ];
-
   public completedItems: ListItem[] = [ ];
-
-  public showCompletedSection: boolean = false;
 
   @ViewChild(ListComponent)
   public listComponent: ListComponent;
@@ -56,9 +53,9 @@ export class HomeComponent implements OnInit {
 
   /**
    * Adds an item to list
-   * 
+   *
    * @param {any} event Event that triggered this addition
-   * @param {HTMLInputElement} entry Input field 
+   * @param {HTMLInputElement} entry Input field
    */
   public add (event: MouseEvent | KeyboardEvent, entry: HTMLInputElement) {
     event.preventDefault();
@@ -77,7 +74,7 @@ export class HomeComponent implements OnInit {
 
   /**
    * Completes an item on the list
-   * 
+   *
    * @param {ListItem} item The item to complete
    * @return {void}
    */
@@ -90,9 +87,9 @@ export class HomeComponent implements OnInit {
 
   /**
    * Marks an already completed item as incomplete
-   * 
+   *
    * @param {ListItem} item The item to mark as incomplete
-   * @return {void} 
+   * @return {void}
    */
   public incomplete (item: ListItem): void {
     this.items.push(item);
@@ -103,22 +100,13 @@ export class HomeComponent implements OnInit {
 
   /**
    * Removes items from both, the incomplete and completed section
-   * 
+   *
    * @param {string[]} items The items to remove
    * @return {void}
    */
   public remove (items: string[]): void {
     localStorage.setItem('entries', JSON.stringify(this.items));
     localStorage.setItem('completed', JSON.stringify(this.completedItems));
-  }
-
-  /**
-   * Toggles visibility of the completed items section
-   * 
-   * @return {void}
-   */
-  public toggleShowCompletedSection (): void {
-    this.showCompletedSection = !this.showCompletedSection;
   }
 
 }

--- a/frontend/webapp/src/app/components/home/home.spec.ts
+++ b/frontend/webapp/src/app/components/home/home.spec.ts
@@ -43,13 +43,4 @@ describe('HomeComponent', () => {
     expect(home.items).toEqual([ 'entry1', 'entry2' ]);
   }));
 
-  it('should toggle the completed section visibility',
-  inject([ HomeComponent ], (home) => {
-    home.showCompletedSection = false;
-    home.toggleShowCompletedSection();
-    expect(home.showCompletedSection).toBe(true);
-    home.toggleShowCompletedSection();
-    expect(home.showCompletedSection).toBe(false);
-  }));
-
 });

--- a/frontend/webapp/src/app/components/home/home.style.scss
+++ b/frontend/webapp/src/app/components/home/home.style.scss
@@ -41,10 +41,6 @@ button {
   border: none;
 }
 
-.toggleCompleted {
-  position: fixed; left: 1em; bottom: 1em;
-}
-
 
 .sublist {
   display: block;

--- a/frontend/webapp/src/app/components/home/home.template.html
+++ b/frontend/webapp/src/app/components/home/home.template.html
@@ -1,21 +1,18 @@
+<sl-completed [completedItems]="completedItems"
+  (onIncomplete)="incomplete($event)" (onRemove)="remove($event)">
+</sl-completed>
+
+<sl-list [items]="items" (onComplete)="complete($event)"></sl-list>
+
+<div *ngIf="!items.length && !completedItems.length" class="empty"><span>No entries</span></div>
+
 <form>
-  <input 
+  <input
     [autoCompletion]="apiService.getAutoCompletion"
     (onSelect)="add($event, entry)"
-    type="text" 
-    placeholder="Add a new entry..." 
+    type="text"
+    placeholder="Add a new entry..."
     #entry
   >
   <button (click)="add($event, entry)"><i class="fa fa-plus"></i></button>
 </form>
-<sl-list [items]="items" (onComplete)="complete($event)"></sl-list>
-
-<button (click)="toggleShowCompletedSection()" class="toggleCompleted">
-  <span *ngIf="!showCompletedSection">Show Completed</span>
-  <span *ngIf="showCompletedSection">Hide Completed</span>
-</button>
-<sl-completed *ngIf="showCompletedSection" [completedItems]="completedItems" 
-  (onIncomplete)="incomplete($event)" (onRemove)="remove($event)">
-</sl-completed>
-
-<div *ngIf="!items.length && !completedItems.length" class="empty"><span>No entries</span></div>


### PR DESCRIPTION
As discussed on saturday, I started reorganizing the list view by putting the completed items section before the actual list section.

Further, it is still open to hide the completed items by default and only show them when the user scrolls up. 